### PR TITLE
Fix error when using a GeoJSON object instead of a url for a source

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -135,7 +135,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log) {
 
             case 'GeoJSON':
                 if (!(source.geojson || source.url)) {
-                    $log.error('[AngularJS - Openlayers] - You need a GeoJSON features ' +
+                    $log.error('[AngularJS - Openlayers] - You need a geojson ' +
                                'property to add a GeoJSON layer.');
                     return;
                 }
@@ -152,8 +152,8 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log) {
                 break;
             case 'TopoJSON':
                 if (!(source.topojson || source.url)) {
-                    $log.error('[AngularJS - Openlayers] - You need a TopoJSON features ' +
-                               'property to add a GeoJSON layer.');
+                    $log.error('[AngularJS - Openlayers] - You need a topojson ' +
+                               'property to add a TopoJSON layer.');
                     return;
                 }
 


### PR DESCRIPTION
Using a GeoJSON object instead of a url for a source resulted in an error: '[AngularJS - Openlayers] - You need a GeoJSON features property to add a GeoJSON layer.'
The existence of a features property was checked for but the geojson property was passed to create an ol.source.GeoJSON object. This updates the condition to check for the geojson property and applies the same fix for the topojson source.
