### PR TITLE
Projection can be defined as string, witch allow to define custom projec...

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -68,18 +68,15 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log) {
         var oProjection;
 
         switch (projection) {
-            case 'EPSG:3857':
-                oProjection = new ol.proj.get(projection);
-                break;
-            case 'EPSG:4326':
-                oProjection = new ol.proj.get(projection);
-                break;
             case 'pixel':
                 oProjection = new ol.proj.Projection({
                     code: 'pixel',
                     units: 'pixels',
                     extent: [0, 0, 4500, 2234]
                 });
+                break;
+            default:
+                oProjection = new ol.proj.get(projection);
                 break;
         }
 


### PR DESCRIPTION
Projection can be defined as string, witch allow to define custom projection with ol.proj.addProjection like this

```
var projection = new ol.proj.Projection({
    code: 'EPSG:31370',
  // The extent is used to determine zoom level 0. Recommended values for a
  // projection's validity extent can be found at http://epsg.io/.
  extent: [42000.0, 19999.75, 296000.0, 168000.0],
  units: 'm'
});
ol.proj.addProjection(projection);
```

By the way, i removed code for EPSG:4326 and EPSG:3857 because they are already defined by default in ol3 http://openlayers.org/en/master/apidoc/ol.proj.Projection.html.

Regards
