### PR TITLE
Allow the user to configure markers to show their label on 'click' as an additional option rather than 'mouseover'

### DIFF
--- a/src/directives/control.js
+++ b/src/directives/control.js
@@ -1,27 +1,27 @@
 angular.module('openlayers-directive')
-       .directive('olControl', function($log, $q, olData, olMapDefaults, olHelpers) {
+    .directive('olControl', function($log, $q, olData, olMapDefaults, olHelpers) {
 
-    return {
-        restrict: 'E',
-        scope: false,
-        replace: false,
-        require: '^openlayers',
-        link: function(scope, element, attrs, controller) {
-            var olScope   = controller.getOpenlayersScope();
-            var control;
+        return {
+            restrict: 'E',
+            scope: false,
+            replace: false,
+            require: '^openlayers',
+            link: function(scope, element, attrs, controller) {
+                var olScope   = controller.getOpenlayersScope();
+                var control;
 
-            olScope.getMap().then(function(map) {
-                var getControlClasses = olHelpers.getControlClasses;
-                var controlClasses = getControlClasses();
-                if (attrs.name) {
-                    control = new controlClasses[attrs.name]();
-                    map.addControl(control);
-                }
+                olScope.getMap().then(function(map) {
+                    var getControlClasses = olHelpers.getControlClasses;
+                    var controlClasses = getControlClasses();
+                    if (attrs.name) {
+                        control = new controlClasses[attrs.name]();
+                        map.addControl(control);
+                    }
 
-                scope.$on('$destroy', function() {
-                    map.removeControl(control);
+                    scope.$on('$destroy', function() {
+                        map.removeControl(control);
+                    });
                 });
-            });
-        }
-    };
-});
+            }
+        };
+    });

--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -1,158 +1,158 @@
 angular.module('openlayers-directive')
-       .directive('olMarker', function($log, $q, olMapDefaults, olHelpers) {
+    .directive('olMarker', function($log, $q, olMapDefaults, olHelpers) {
 
-    var getMarkerDefaults = function() {
-        return {
-            projection: 'EPSG:4326',
-            lat: 0,
-            lon: 0,
-            coord: [],
-            show: true,
-            showOnMouseOver: false
+        var getMarkerDefaults = function() {
+            return {
+                projection: 'EPSG:4326',
+                lat: 0,
+                lon: 0,
+                coord: [],
+                show: true,
+                showOnMouseOver: false
+            };
         };
-    };
 
-    return {
-        restrict: 'E',
-        scope: {
-            lat: '=lat',
-            lon: '=lon',
-            label: '=label',
-            properties: '=olMarkerProperties'
-        },
-        require: '^openlayers',
-        replace: true,
-        template: '<div class="popup-label marker" ng-bind-html="message"></div>',
+        return {
+            restrict: 'E',
+            scope: {
+                lat: '=lat',
+                lon: '=lon',
+                label: '=label',
+                properties: '=olMarkerProperties'
+            },
+            require: '^openlayers',
+            replace: true,
+            template: '<div class="popup-label marker" ng-bind-html="message"></div>',
 
-        link: function(scope, element, attrs, controller) {
-            var isDefined = olHelpers.isDefined;
-            var olScope = controller.getOpenlayersScope();
-            var createVectorLayer = olHelpers.createVectorLayer;
-            var createFeature = olHelpers.createFeature;
-            var createOverlay = olHelpers.createOverlay;
+            link: function(scope, element, attrs, controller) {
+                var isDefined = olHelpers.isDefined;
+                var olScope = controller.getOpenlayersScope();
+                var createVectorLayer = olHelpers.createVectorLayer;
+                var createFeature = olHelpers.createFeature;
+                var createOverlay = olHelpers.createOverlay;
 
-            olScope.getMap().then(function(map) {
-                var markerLayer = createVectorLayer();
-                markerLayer.set('markers', true);
-                map.addLayer(markerLayer);
-                var data = getMarkerDefaults();
+                olScope.getMap().then(function(map) {
+                    var markerLayer = createVectorLayer();
+                    markerLayer.set('markers', true);
+                    map.addLayer(markerLayer);
+                    var data = getMarkerDefaults();
 
-                var mapDefaults = olMapDefaults.getDefaults(olScope);
-                var viewProjection = mapDefaults.view.projection;
-                var label;
-                var pos;
-                var marker;
+                    var mapDefaults = olMapDefaults.getDefaults(olScope);
+                    var viewProjection = mapDefaults.view.projection;
+                    var label;
+                    var pos;
+                    var marker;
 
-                scope.$on('$destroy', function() {
-                    map.removeLayer(markerLayer);
-                });
+                    scope.$on('$destroy', function() {
+                        map.removeLayer(markerLayer);
+                    });
 
-                if (!isDefined(scope.properties)) {
-                    data.lat = scope.lat ? scope.lat : data.lat;
-                    data.lon = scope.lon ? scope.lon : data.lon;
-                    data.message = attrs.message;
-                    data.style = mapDefaults.styles.marker;
-
-                    marker = createFeature(data, viewProjection);
-                    if (!isDefined(marker)) {
-                        $log.error('[AngularJS - Openlayers] Received invalid data on ' +
-                                   'the marker.');
-                    }
-                    markerLayer.getSource().addFeature(marker);
-
-                    if (data.message) {
-                        scope.message = attrs.message;
-                        pos = ol.proj.transform([data.lon, data.lat], data.projection, viewProjection);
-                        label = createOverlay(element, pos);
-                        map.addOverlay(label);
-                    }
-                    return;
-                }
-
-                scope.$watch('properties', function(properties) {
-                    if (!isDefined(marker)) {
-                        data.projection = properties.projection ? properties.projection : data.projection;
-                        data.coord = properties.coord ? properties.coord : data.coord;
-                        data.lat = properties.lat ? properties.lat : data.lat;
-                        data.lon = properties.lon ? properties.lon : data.lon;
-
-                        if (isDefined(properties.style)) {
-                            data.style = properties.style;
-                        } else {
-                            data.style = mapDefaults.styles.marker;
-                        }
+                    if (!isDefined(scope.properties)) {
+                        data.lat = scope.lat ? scope.lat : data.lat;
+                        data.lon = scope.lon ? scope.lon : data.lon;
+                        data.message = attrs.message;
+                        data.style = mapDefaults.styles.marker;
 
                         marker = createFeature(data, viewProjection);
                         if (!isDefined(marker)) {
                             $log.error('[AngularJS - Openlayers] Received invalid data on ' +
-                                       'the marker.');
+                            'the marker.');
                         }
                         markerLayer.getSource().addFeature(marker);
-                    }
 
-                    if (isDefined(label)) {
-                        map.removeOverlay(label);
-                    }
-
-                    if (!isDefined(properties.label)) {
-                        return;
-                    }
-
-                    scope.message = properties.label.message;
-                    if (!isDefined(scope.message) || scope.message.length === 0) {
-                        return;
-                    }
-
-                    if (properties.label && properties.label.show === true) {
-                        if (data.projection === 'pixel') {
-                            pos = data.coord;
-                        } else {
+                        if (data.message) {
+                            scope.message = attrs.message;
                             pos = ol.proj.transform([data.lon, data.lat], data.projection, viewProjection);
+                            label = createOverlay(element, pos);
+                            map.addOverlay(label);
                         }
-                        label = createOverlay(element, pos);
-                        map.addOverlay(label);
+                        return;
                     }
 
-                    if (label && properties.label && properties.label.show === false) {
-                        map.removeOverlay(label);
-                        label = undefined;
-                    }
+                    scope.$watch('properties', function(properties) {
+                        if (!isDefined(marker)) {
+                            data.projection = properties.projection ? properties.projection : data.projection;
+                            data.coord = properties.coord ? properties.coord : data.coord;
+                            data.lat = properties.lat ? properties.lat : data.lat;
+                            data.lon = properties.lon ? properties.lon : data.lon;
 
-                    if (properties.label && properties.label.show === false && properties.label.showOnMouseOver) {
-                        map.getViewport().addEventListener('mousemove', function(evt) {
-                            if (properties.label.show) {
-                                return;
+                            if (isDefined(properties.style)) {
+                                data.style = properties.style;
+                            } else {
+                                data.style = mapDefaults.styles.marker;
                             }
-                            var found = false;
-                            var pixel = map.getEventPixel(evt);
-                            var feature = map.forEachFeatureAtPixel(pixel, function(feature) {
-                                return feature;
-                            });
 
-                            if (feature === marker) {
-                                found = true;
-                                if (!isDefined(label)) {
-                                    if (data.projection === 'pixel') {
-                                        pos = data.coord;
-                                    } else {
-                                        pos = ol.proj.transform([data.lon, data.lat],
-                                                                data.projection, viewProjection);
-                                    }
-                                    label = createOverlay(element, pos);
-                                    map.addOverlay(label);
+                            marker = createFeature(data, viewProjection);
+                            if (!isDefined(marker)) {
+                                $log.error('[AngularJS - Openlayers] Received invalid data on ' +
+                                'the marker.');
+                            }
+                            markerLayer.getSource().addFeature(marker);
+                        }
+
+                        if (isDefined(label)) {
+                            map.removeOverlay(label);
+                        }
+
+                        if (!isDefined(properties.label)) {
+                            return;
+                        }
+
+                        scope.message = properties.label.message;
+                        if (!isDefined(scope.message) || scope.message.length === 0) {
+                            return;
+                        }
+
+                        if (properties.label && properties.label.show === true) {
+                            if (data.projection === 'pixel') {
+                                pos = data.coord;
+                            } else {
+                                pos = ol.proj.transform([data.lon, data.lat], data.projection, viewProjection);
+                            }
+                            label = createOverlay(element, pos);
+                            map.addOverlay(label);
+                        }
+
+                        if (label && properties.label && properties.label.show === false) {
+                            map.removeOverlay(label);
+                            label = undefined;
+                        }
+
+                        if (properties.label && properties.label.show === false && properties.label.showOnMouseOver) {
+                            map.getViewport().addEventListener('mousemove', function(evt) {
+                                if (properties.label.show) {
+                                    return;
                                 }
-                                map.getTarget().style.cursor = 'pointer';
-                            }
+                                var found = false;
+                                var pixel = map.getEventPixel(evt);
+                                var feature = map.forEachFeatureAtPixel(pixel, function(feature) {
+                                    return feature;
+                                });
 
-                            if (!found && label) {
-                                map.removeOverlay(label);
-                                label = undefined;
-                                map.getTarget().style.cursor = '';
-                            }
-                        });
-                    }
-                }, true);
-            });
-        }
-    };
-});
+                                if (feature === marker) {
+                                    found = true;
+                                    if (!isDefined(label)) {
+                                        if (data.projection === 'pixel') {
+                                            pos = data.coord;
+                                        } else {
+                                            pos = ol.proj.transform([data.lon, data.lat],
+                                                data.projection, viewProjection);
+                                        }
+                                        label = createOverlay(element, pos);
+                                        map.addOverlay(label);
+                                    }
+                                    map.getTarget().style.cursor = 'pointer';
+                                }
+
+                                if (!found && label) {
+                                    map.removeOverlay(label);
+                                    label = undefined;
+                                    map.getTarget().style.cursor = '';
+                                }
+                            });
+                        }
+                    }, true);
+                });
+            }
+        };
+    });

--- a/src/directives/path.js
+++ b/src/directives/path.js
@@ -1,49 +1,49 @@
 angular.module('openlayers-directive')
-        .directive('olPath', function($log, $q, olMapDefaults, olHelpers) {
+    .directive('olPath', function($log, $q, olMapDefaults, olHelpers) {
 
-    return {
-        restrict: 'E',
-        scope: {
-            properties: '=olGeomProperties'
-        },
-        require: '^openlayers',
-        replace: true,
-        template: '<div class="popup-label path" ng-bind-html="message"></div>',
+        return {
+            restrict: 'E',
+            scope: {
+                properties: '=olGeomProperties'
+            },
+            require: '^openlayers',
+            replace: true,
+            template: '<div class="popup-label path" ng-bind-html="message"></div>',
 
-        link: function(scope, element, attrs, controller) {
-            var isDefined = olHelpers.isDefined;
-            var createFeature = olHelpers.createFeature;
-            var createOverlay = olHelpers.createOverlay;
-            var createVectorLayer = olHelpers.createVectorLayer;
-            var olScope = controller.getOpenlayersScope();
+            link: function(scope, element, attrs, controller) {
+                var isDefined = olHelpers.isDefined;
+                var createFeature = olHelpers.createFeature;
+                var createOverlay = olHelpers.createOverlay;
+                var createVectorLayer = olHelpers.createVectorLayer;
+                var olScope = controller.getOpenlayersScope();
 
-            olScope.getMap().then(function(map) {
-                var mapDefaults = olMapDefaults.getDefaults(olScope);
-                var viewProjection = mapDefaults.view.projection;
+                olScope.getMap().then(function(map) {
+                    var mapDefaults = olMapDefaults.getDefaults(olScope);
+                    var viewProjection = mapDefaults.view.projection;
 
-                var layer = createVectorLayer();
-                map.addLayer(layer);
-                if (isDefined(attrs.coords)) {
-                    var proj = attrs.proj || 'EPSG:4326';
-                    var coords = JSON.parse(attrs.coords);
-                    var data = {
-                        type: 'Polygon',
-                        coords: coords,
-                        projection: proj,
-                        style: mapDefaults.styles.path
-                    };
-                    var feature = createFeature(data, viewProjection);
-                    layer.getSource().addFeature(feature);
+                    var layer = createVectorLayer();
+                    map.addLayer(layer);
+                    if (isDefined(attrs.coords)) {
+                        var proj = attrs.proj || 'EPSG:4326';
+                        var coords = JSON.parse(attrs.coords);
+                        var data = {
+                            type: 'Polygon',
+                            coords: coords,
+                            projection: proj,
+                            style: mapDefaults.styles.path
+                        };
+                        var feature = createFeature(data, viewProjection);
+                        layer.getSource().addFeature(feature);
 
-                    if (attrs.message) {
-                        scope.message = attrs.message;
-                        var extent = feature.getGeometry().getExtent();
-                        var label = createOverlay(element, extent);
-                        map.addOverlay(label);
+                        if (attrs.message) {
+                            scope.message = attrs.message;
+                            var extent = feature.getGeometry().getExtent();
+                            var label = createOverlay(element, extent);
+                            map.addOverlay(label);
+                        }
+                        return;
                     }
-                    return;
-                }
-            });
-        }
-    };
-});
+                });
+            }
+        };
+    });

--- a/src/services/olMapDefaults.js
+++ b/src/services/olMapDefaults.js
@@ -130,6 +130,10 @@ angular.module('openlayers-directive').factory('olMapDefaults', function($q, olH
                     newDefaults.view.extent = userDefaults.view.extent || newDefaults.view.extent;
                 }
 
+                if (isDefined(userDefaults.styles)) {
+                    newDefaults.styles = angular.extend(newDefaults.styles, userDefaults.styles);
+                }
+
             }
 
             defaults[scopeId] = newDefaults;


### PR DESCRIPTION
This PR introduces the 'showOnMouseClick' property which can be set on the label attributes associated with the marker's properties.
I also re-indented the some of the code since the JSCS validator was failing without it.