### PR TITLE
The extent property of a ol.layer.Base component should be editable.

### DIFF
--- a/src/directives/layer.js
+++ b/src/directives/layer.js
@@ -77,6 +77,10 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
                         if (properties.opacity) {
                             olLayer.setOpacity(properties.opacity);
                         }
+                        
+                        if (angular.isArray(properties.extent)) {
+                            olLayer.setExtent(properties.extent);
+                        }
 
                         if (properties.style) {
                             if (!angular.isFunction(properties.style)) {


### PR DESCRIPTION
ol.layer.Base/Tile/etc. offer more functionality than the directive offers by now. Extent is one of the most important ones.

It should be either evaluated which fields are necessary es well or they could be added on demand.