### PR TITLE
Support for MapBox as a tile source

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -152,6 +152,25 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
         var oSource;
 
         switch (source.type) {
+            case 'MapBox':
+                if (!source.mapId || !source.accessToken) {
+                    $log.error('[AngularJS - Openlayers] - MapBox layer requires the map id and the access token');
+                    return;
+                }
+                var url = 'http://api.tiles.mapbox.com/v4/' + source.mapId + '/{z}/{x}/{y}.png?access_token=' +
+                    source.accessToken;
+
+                var pixelRatio = window.goog.dom.getPixelRatio();
+
+                if (pixelRatio > 1) {
+                    url = url.replace('.png', '@2x.png');
+                }
+
+                oSource = new ol.source.XYZ({
+                    url: url,
+                    tilePixelRatio: pixelRatio > 1 ? 2 : 1
+                });
+                break;
             case 'ImageWMS':
                 if (!source.url || !source.params) {
                     $log.error('[AngularJS - Openlayers] - ImageWMS Layer needs ' +

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -160,7 +160,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 var url = 'http://api.tiles.mapbox.com/v4/' + source.mapId + '/{z}/{x}/{y}.png?access_token=' +
                     source.accessToken;
 
-                var pixelRatio = window.goog.dom.getPixelRatio();
+                var pixelRatio = window.devicePixelRatio;
 
                 if (pixelRatio > 1) {
                     url = url.replace('.png', '@2x.png');


### PR DESCRIPTION
Supporting MapBox as a tile source for layers, which also switches to an alternative tile set that MapBox offers for high DPI screens if the screen pixel ratio is larger than 1. (gives the map a sharper look on mobile devices)