### PR TITLE
Changed the touchend listener to be placed on the canvas directly

### DIFF
--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -164,7 +164,7 @@ angular.module('openlayers-directive')
 
                         if (properties.label && properties.label.show === false && properties.label.showOnMouseClick) {
                             map.getViewport().addEventListener('click', showLabelOnEvent);
-                            map.getViewport().addEventListener('touchend', showLabelOnEvent);
+                            map.getViewport().querySelector('canvas.ol-unselectable').addEventListener('touchend', showLabelOnEvent);
                         }
                     }, true);
                 });


### PR DESCRIPTION
This is an addition to https://github.com/tombatossals/angular-openlayers-directive/pull/64
 
It regains the possibility of listening to 'touchend' events on overlays.
(like tapping marker label's contents, in my use case)