### PR TITLE
Optimized marker layer management

### DIFF
--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -90,7 +90,7 @@ angular.module('openlayers-directive')
                     var marker;
 
                     scope.$on('$destroy', function() {
-                        markerLayerManager.deregisterScope(scope);
+                        markerLayerManager.deregisterScope(scope, map);
                     });
 
                     if (!isDefined(scope.properties)) {

--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -12,6 +12,55 @@ angular.module('openlayers-directive')
             };
         };
 
+        var markerLayerManager = (function() {
+            var mapDict = [];
+
+            function getMapIndex(map) {
+                return mapDict.map(function(record) {
+                    return record.map;
+                }).indexOf(map);
+            }
+
+            return {
+                getInst: function getMarkerLayerInst(scope, map) {
+                    var mapIndex = getMapIndex(map);
+
+                    if (mapIndex === -1) {
+                        var markerLayer = olHelpers.createVectorLayer();
+                        markerLayer.set('markers', true);
+                        map.addLayer(markerLayer);
+                        mapDict.push({
+                            map: map,
+                            markerLayer: markerLayer,
+                            instScopes: []
+                        });
+                        mapIndex = mapDict.length - 1;
+                    }
+
+                    mapDict[mapIndex].instScopes.push(scope);
+
+                    return mapDict[mapIndex].markerLayer;
+                },
+                deregisterScope: function deregisterScope(scope, map) {
+                    var mapIndex = getMapIndex(map);
+                    if (mapIndex === -1) {
+                        throw Error('This map has no markers');
+                    }
+
+                    var scopes = mapDict[mapIndex].instScopes;
+                    var scopeIndex = scopes.indexOf(scope);
+                    if (scopeIndex === -1) {
+                        throw Error('Scope wan\'t registered');
+                    }
+
+                    scopes.splice(scopeIndex, 1);
+
+                    if (!scopes.length) {
+                        map.removeLayer(mapDict[mapIndex].markerLayer);
+                    }
+                }
+            };
+        })();
         return {
             restrict: 'E',
             scope: {
@@ -27,14 +76,11 @@ angular.module('openlayers-directive')
             link: function(scope, element, attrs, controller) {
                 var isDefined = olHelpers.isDefined;
                 var olScope = controller.getOpenlayersScope();
-                var createVectorLayer = olHelpers.createVectorLayer;
                 var createFeature = olHelpers.createFeature;
                 var createOverlay = olHelpers.createOverlay;
 
                 olScope.getMap().then(function(map) {
-                    var markerLayer = createVectorLayer();
-                    markerLayer.set('markers', true);
-                    map.addLayer(markerLayer);
+                    var markerLayer = markerLayerManager.getInst(scope, map);
                     var data = getMarkerDefaults();
 
                     var mapDefaults = olMapDefaults.getDefaults(olScope);
@@ -44,7 +90,7 @@ angular.module('openlayers-directive')
                     var marker;
 
                     scope.$on('$destroy', function() {
-                        map.removeLayer(markerLayer);
+                        markerLayerManager.deregisterScope(scope);
                     });
 
                     if (!isDefined(scope.properties)) {

--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -57,6 +57,7 @@ angular.module('openlayers-directive')
 
                     if (!scopes.length) {
                         map.removeLayer(mapDict[mapIndex].markerLayer);
+                        delete mapDict[mapIndex];
                     }
                 }
             };


### PR DESCRIPTION
This PR optimizes the usage of markers by limiting the number of vector layers used by markers on a single map instance to 1, instead of having one vector layer per marker.
It's doing that by keeping the reference to the layer designated for markers for each map and providing it when a marker is on created on a specific map.
This improves both rendering performance and helps avoid the openlayers maximum layer count (which is around 75).