### PR TITLE
Allows to transclude content for marker labels

### DIFF
--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -71,15 +71,22 @@ angular.module('openlayers-directive')
                 label: '=label',
                 properties: '=olMarkerProperties'
             },
+            transclude: true,
             require: '^openlayers',
             replace: true,
-            template: '<div class="popup-label marker" ng-bind-html="message"></div>',
+            template:
+            '<div class="popup-label marker">' +
+                '<div ng-bind-html="message"></div>' +
+                '<ng-transclude></ng-transclude>' +
+            '</div>',
 
             link: function(scope, element, attrs, controller) {
                 var isDefined = olHelpers.isDefined;
                 var olScope = controller.getOpenlayersScope();
                 var createFeature = olHelpers.createFeature;
                 var createOverlay = olHelpers.createOverlay;
+
+                var hasTranscluded = element.find('ng-transclude').children().length > 0;
 
                 olScope.getMap().then(function(map) {
                     var markerLayer = markerLayerManager.getInst(scope, map);
@@ -108,7 +115,7 @@ angular.module('openlayers-directive')
                         }
                         markerLayer.getSource().addFeature(marker);
 
-                        if (data.message) {
+                        if (data.message || hasTranscluded) {
                             scope.message = attrs.message;
                             pos = ol.proj.transform([data.lon, data.lat], data.projection,
                                 viewProjection);
@@ -188,7 +195,7 @@ angular.module('openlayers-directive')
                         }
 
                         scope.message = properties.label.message;
-                        if (!isDefined(scope.message) || scope.message.length === 0) {
+                        if (!hasTranscluded && (!isDefined(scope.message) || scope.message.length === 0)) {
                             return;
                         }
 


### PR DESCRIPTION
This provides an alternative method for specifying the content for marker labels, by enabling 'transclude' on the marker directive and handing the label if the existing method is used or the new one.
By doing this, content bound to an angular scope can be placed in the label, so the label could handle user input.