### PR TITLE
Added index to layers and optionally to properties (fixes #72)

### DIFF
--- a/src/directives/layer.js
+++ b/src/directives/layer.js
@@ -18,13 +18,17 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
             var isBoolean   = olHelpers.isBoolean;
             var addLayerBeforeMarkers = olHelpers.addLayerBeforeMarkers;
             var isNumber    = olHelpers.isNumber;
+            var insertLayer = olHelpers.insertLayer;
+            var removeLayer = olHelpers.removeLayer;
 
             olScope.getMap().then(function(map) {
                 var projection = map.getView().getProjection();
                 var defaults = olMapDefaults.setDefaults(olScope);
+                var layerCollection = map.getLayers();
                 var olLayer;
 
                 scope.$on('$destroy', function() {
+                    removeLayer(layerCollection, olLayer.index);
                     map.removeLayer(olLayer);
                 });
 
@@ -41,7 +45,7 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
                         if (detectLayerType(l) === 'Vector') {
                             setVectorLayerEvents(defaults.events, map, scope, attrs.name);
                         }
-                        addLayerBeforeMarkers(map.getLayers(), olLayer);
+                        addLayerBeforeMarkers(layerCollection, olLayer);
                     }
                     return;
                 }
@@ -64,7 +68,11 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
                     var style;
                     if (!isDefined(olLayer)) {
                         olLayer = createLayer(properties, projection);
-                        addLayerBeforeMarkers(map.getLayers(), olLayer);
+                        if (isDefined(properties.index)) {
+                            insertLayer(layerCollection, properties.index, olLayer);
+                        } else {
+                            addLayerBeforeMarkers(layerCollection, olLayer);
+                        }
 
                         if (detectLayerType(properties) === 'Vector') {
                             setVectorLayerEvents(defaults.events, map, scope, properties.name);
@@ -94,22 +102,21 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
                     } else {
                         if (isDefined(oldProperties) && !equals(properties, oldProperties)) {
                             if (!equals(properties.source, oldProperties.source)) {
-                                var layerCollection = map.getLayers();
+                                var idx = olLayer.index;
+                                layerCollection.setAt(idx, null);
+                                olLayer = createLayer(properties, projection);
+                                if (isDefined(olLayer)) {
+                                    insertLayer(layerCollection, idx, olLayer);
 
-                                for (var j = 0; j < layerCollection.getLength(); j++) {
-                                    var l = layerCollection.item(j);
-                                    if (l === olLayer) {
-                                        layerCollection.removeAt(j);
-                                        olLayer = createLayer(properties, projection);
-                                        if (isDefined(olLayer)) {
-                                            layerCollection.insertAt(j, olLayer);
-
-                                            if (detectLayerType(properties) === 'Vector') {
-                                                setVectorLayerEvents(defaults.events, map, scope, properties.name);
-                                            }
-                                        }
+                                    if (detectLayerType(properties) === 'Vector') {
+                                        setVectorLayerEvents(defaults.events, map, scope, properties.name);
                                     }
                                 }
+                            }
+
+                            if (isDefined(properties.index) && properties.index !== olLayer.index) {
+                                removeLayer(layerCollection, olLayer.index);
+                                insertLayer(layerCollection, properties.index, olLayer);
                             }
 
                             if (isBoolean(properties.visible) && properties.visible !== oldProperties.visible) {

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -654,12 +654,50 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
 
             if (isDefined(markersIndex)) {
                 var markers = layers.item(markersIndex);
+                layer.index = markersIndex;
                 layers.setAt(markersIndex, layer);
+                markers.index = layers.getLength();
                 layers.push(markers);
             } else {
+                layer.index = layers.getLength();
                 layers.push(layer);
             }
 
+        },
+
+        removeLayer: function(layers, index) {
+            layers.removeAt(index);
+            for (var i = index; i < layers.getLength(); i++) {
+                var l = layers.item(i);
+                if (l === null) {
+                    layers.insertAt(i, null);
+                    break;
+                } else {
+                    l.index = i;
+                }
+            }
+        },
+
+        insertLayer: function(layers, index, layer) {
+            if (layers.getLength() < index) {
+                while (layers.getLength() < index) {
+                    layers.push(null);
+                }
+                layer.index = index;
+                layers.push(layer);
+            } else {
+                layer.index = index;
+                layers.insertAt(layer.index, layer);
+                for (var i = index + 1; i < layers.getLength(); i++) {
+                    var l = layers.item(i);
+                    if (l === null) {
+                        layers.removeAt(i);
+                        break;
+                    } else {
+                        l.index = i;
+                    }
+                }
+            }
         },
 
         createOverlay: function(element, pos) {


### PR DESCRIPTION
If the user adds an index property to the `ol-layer-properties`, the code now tries to maintain that layer number. It only enforces the index when

1. the layer is added
2. the layer properties (or index) are modified

The changes require all code to use olHelpers code to access the `ol.Map.getLayers()` layer collection. If the indicated index is larger than the number of layers, `null` layers are inserted until the number of layers is correct. When inserting or removing a layer, all subsequent layers are shifted until a `null` value is encountered, so that layers after a `null` layer are not shifted.

The use of an index by the user is optional. Users can update the underlying array as follows:

JavaScript:
```
$scope.layers = [layer1, layer2]
$scope.updateLayerOrder = function() {
    $scope.layers.map(function(layer, idx){ layer.index = idx; });
}
```
HTML
```
<openlayers custom-layers="true">
<ol-layer ng-repeat="layer in layers track by layer.name" ol-layer-properties="layer"></ol-layer>
</openlayers>
```

An alternative implementation that I considered: watch the ol-layer element index compared to its siblings, and use that index. This requires less change from the user, but I couldn't find a way to integrate it in the code.