### PR TITLE
Circles and style functions

### DIFF
--- a/examples/045-layers-geojson-example.html
+++ b/examples/045-layers-geojson-example.html
@@ -64,19 +64,24 @@
                 }
             },
             {
-                name: 'Portugal',
+                name: 'Lisbon',
                 source: {
                     type: 'GeoJSON',
-                    url: 'json/PRT.geo.json'
+                    url: 'json/LIS.geo.json'
                 },
                 style: {
-                    fill: {
-                        color: 'rgba(0, 0, 255, 0.6)'
-                    },
-                    stroke: {
-                        color: 'white',
-                        width: 3
-                    }
+                    image: {
+                      circle: {
+                            radius: 8,
+			    fill: {
+				color: 'rgba(0, 0, 255, 0.6)'
+			    },
+			    stroke: {
+				color: 'white',
+				width: 3
+			    }
+                         }
+                     }
                 }
             }]
         });

--- a/examples/058-layers-geojson-style-function.html
+++ b/examples/058-layers-geojson-style-function.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html ng-app="demoapp">
+<head>
+    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/angular/angular.min.js"></script>
+    <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
+    <script src="../dist/angular-openlayers-directive.js"></script>
+    <link rel="stylesheet" href="openlayers3/build/ol.css" />
+    <script>
+        var app = angular.module("demoapp", ["openlayers-directive"]);
+        app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {
+
+            $http.get('json/features.json').success(function(data) {
+                var features = data;
+                $scope.feat = {
+                    source: {
+                        type: 'GeoJSON',
+                        geojson: {
+                            object: features,
+                            projection: 'EPSG:3857'
+                        }
+                    },
+                    style: (function() {
+                        var someStyle = [new ol.style.Style({
+                            fill: new ol.style.Fill({
+                                color: 'blue'
+                            }),
+                            stroke: new ol.style.Stroke({
+                                color: 'olive',
+                                width: 1
+                            })
+                        })];
+                        var otherStyle = function(r,c){ return [new ol.style.Style({
+                            image: new ol.style.Circle({
+                                radius: r,
+                                fill: new ol.style.Fill({
+                                    color: c
+                                })
+                            })
+                        })]};
+                        return function(feature, resolution) {
+                            if (feature.get('class') === "someClass") {
+                                return someStyle;
+                            } else {
+                                return otherStyle(feature.get('radius'), feature.get('color'));
+                            }
+                        };
+                    }())
+                }
+            });
+
+            angular.extend($scope, {
+                charlotte: {
+                    lat: 35.30674709224663,
+                    lon: -80.83827000459532,
+                    zoom: 11
+                },
+                feat: {}
+            });
+        } ]);
+    </script>
+</head>
+<body ng-controller="GeoJSONController">
+<openlayers ol-center="charlotte" height="400px">
+    <ol-layer ol-layer-properties="feat"></ol-layer>
+</openlayers>
+<h1>Layers GeoJSON features with different styles example</h1>
+<p>You can define a function to set the style for features based on properties </p>
+<pre ng-bind="feat | json"></pre>
+</body>
+</html>

--- a/examples/json/LIS.geo.json
+++ b/examples/json/LIS.geo.json
@@ -1,0 +1,3 @@
+{"type":"FeatureCollection","features":[
+{"type":"Feature","id":"PRT","properties":{"name":"Lisbon"},"geometry":{"type":"Point","coordinates":[-9.394, 38.7139]}}
+]}

--- a/examples/json/features.json
+++ b/examples/json/features.json
@@ -1,0 +1,101 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -80.87088507656375,
+                    35.21515162500578
+                ]
+            },
+            "properties": {
+                "name": "ABBOTT NEIGHBORHOOD PARK",
+                "address": "1300  SPRUCE ST",
+                "radius": 5,
+                "color": "black"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -80.83775386582222,
+                    35.24980190252168
+                ]
+            },
+            "properties": {
+                "name": "DOUBLE OAKS CENTER",
+                "address": "1326 WOODWARD AV",
+                "radius": 6,
+                "color": "red"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -80.83827000459532,
+                    35.25674709224663
+                ]
+            },
+            "properties": {
+                "name": "DOUBLE OAKS NEIGHBORHOOD PARK",
+                "address": "2605  DOUBLE OAKS RD",
+                "radius": 7,
+                "color": "yellow"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -80.83697759172735,
+                    35.25751734669229
+                ]
+            },
+            "properties": {
+                "name": "DOUBLE OAKS POOL",
+                "address": "1200 NEWLAND RD",
+                "radius": 8,
+                "color": "orange"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -80.81647652154736,
+                    35.40148708491418
+                ]
+            },
+            "properties": {
+                "name": "DAVID B. WAYMER FLYING REGIONAL PARK",
+                "address": "15401 HOLBROOKS RD",
+                "radius": 9,
+                "color": "green"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -80.83556459443902,
+                    35.39917224760999
+                ]
+            },
+            "properties": {
+                "name": "DAVID B. WAYMER COMMUNITY PARK",
+                "address": "302 HOLBROOKS RD",
+                "radius": 10,
+                "color": "blue"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Addresses issues #51 #74 #57.
The createLayer function is now recursive and parses style trees such as:
style:{
  image:{
    circle: {
        radius: 5,
        fill: {
              color: 'red'
         }
   }
}

In addition, we can now handle the case where someone creates a tree that also contains an openlayers style constructor.  In the above, fill could instead be:
fill: new ol.layers.Fill({
   color: 'red'
})
This way users of this directive will have access to any style features that may not be included in the tree parsing.

The last change is that we can have a function for the style.  The new example 058 shows an example.  There is some extraneous junk in the function that I should remove.