### PR TITLE
Allow to specify the "urls" property in the case of TileWMS services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+lib
 temp
 node_modules
 libpeerconnection.log

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -232,14 +232,24 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 break;
 
             case 'TileWMS':
-                if (!source.url || !source.params) {
-                    $log.error('[AngularJS - Openlayers] - TileWMS Layer needs valid url and params properties');
+                if ((!source.url && !source.urls) || !source.params) {
+                    $log.error('[AngularJS - Openlayers] - TileWMS Layer needs valid url (or urls) and params properties');
                 }
-                oSource = new ol.source.TileWMS({
-                  url: source.url,
+
+                var wmsConfiguration = {
                   crossOrigin: source.crossOrigin ? source.crossOrigin : 'anonymous',
                   params: source.params
-                });
+                };
+
+                if(wmsConfiguration.url){
+                    wmsConfiguration.url = source.url;
+                }
+
+                if(source.urls){
+                    wmsConfiguration.urls = source.urls;
+                }
+
+                oSource = new ol.source.TileWMS(wmsConfiguration);
                 break;
             case 'OSM':
                 if (source.attribution) {


### PR DESCRIPTION
Hi,

we're developing a GIS application on the basis of Angular and OpenLayers and I just started to use your directive (which btw is supercool).

What I discovered, though, is that in the case of TileWMS services it is currently not possible to use the `urls` property.

```javascript
case 'TileWMS':
     if (!source.url || !source.params) {
            $log.error('[AngularJS - Openlayers] - TileWMS Layer needs valid url and params properties');
     }
     ...
```

Instead, OpenLayers permits to have a confguration like this:

```javascript
new ol.layer.Tile({
    title: "My title",
    source: new ol.source.TileWMS({
        urls: [
            'http://url1/geoserver/wms',
            'http://url2/geoserver/wms',
            'http://url3/geoserver/wms',
        ],
        params: {
            LAYERS: 'SomeLayerName'
        },
        serverType: 'geoserver'
    })
}),
```
This PR fixes the issue. Please have a look and it would be cool if you could merge it in and release a new version on bower. I'd like to use this directive for our application and contribute to it where extensions/adjustments are necessary :smiley: 

Keep up the good work, thx!