### PR TITLE
Allow setting the extent that constrains the center

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -464,7 +464,8 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
             return new ol.View({
                 projection: projection,
                 maxZoom: view.maxZoom,
-                minZoom: view.minZoom
+                minZoom: view.minZoom,
+                extent: view.extent
             });
         },
 


### PR DESCRIPTION
in other words, center cannot be set outside this extent.
In my case it was crucial so user cannot pan outside of the map.

Documented in http://openlayers.org/en/v3.3.0/apidoc/ol.View.html?unstable=true