### PR TITLE
Optional function to load an image given a URL

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -441,7 +441,8 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     url: source.url,
                     imageSize: source.imageSize,
                     projection: projection,
-                    imageExtent: projection.getExtent()
+                    imageExtent: projection.getExtent(),
+                    imageLoadFunction: source.imageLoadFunction
                 });
                 break;
         }


### PR DESCRIPTION
Relevant only to ol.source.ImageStatic source.

A function that takes an ol.Image for the image and a {string} for the src as arguments. It is supposed to make it so the underlying image ol.Image#getImage is assigned the content specified by the src. If not specified, the default is

```javascript
function(image, src) {
  image.getImage().src = src;
}
```

Providing a custom imageLoadFunction can be useful to load images with post requests or - in general - through XHR requests, where the src of the image element would be set to a data URI when the content is loaded.