### PR TITLE
Fix for setting of the layer name

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -611,7 +611,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
 
         detectLayerType: detectLayerType,
 
-        createLayer: function(layer, projection) {
+        createLayer: function(layer, projection, name) {
             var oLayer;
             var type = detectLayerType(layer);
             var oSource = createSource(layer.source, projection);
@@ -632,6 +632,13 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 case 'Vector':
                     oLayer = new ol.layer.Vector({ source: oSource });
                     break;
+            }
+
+            // set a layer name if given
+            if (isDefined(name)) {
+                oLayer.set('name', name);
+            } else if (isDefined(layer.name)) {
+                oLayer.set('name', layer.name);
             }
 
             return oLayer;


### PR DESCRIPTION
This piece of code doesn't work any more in the latest version:

```javascript
olData.getMap().then(function(map) {
    var layers = map.getLayers();
    layers.forEach(function(layer) {
        if (layer.get('name') === 'japan') {
            var extent = layer.getSource().getExtent();
            map.getView().fitExtent(extent, map.getSize());
        }
    })
});
```

The problem is that the layer name is no more set correctly as already mentioned in issue #92. This PR fixes it.

_Btw, one should add tests to make sure this doesn't happen again. I'd also be willing to add them, but the current tests on master don't pass and it would take me too long to figure out why._