### PR TITLE
Marker option to handle click and tap events

### DIFF
--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -126,7 +126,7 @@ angular.module('openlayers-directive')
                     }
 
                     scope.$watch('properties', function(properties) {
-                        function showLabelOnEvent(evt) {
+                        function handleInteraction(evt) {
                             if (properties.label.show) {
                                 return;
                             }
@@ -149,6 +149,10 @@ angular.module('openlayers-directive')
                                     }
                                     label = createOverlay(element, pos);
                                     map.addOverlay(label);
+                                }
+
+                                if (properties.onClick && (evt.type === 'click' || evt.type === 'touchend')) {
+                                    properties.onClick.call(marker, evt, properties);
                                 }
                                 map.getTarget().style.cursor = 'pointer';
                             }
@@ -217,14 +221,15 @@ angular.module('openlayers-directive')
 
                         if (properties.label && properties.label.show === false &&
                             properties.label.showOnMouseOver) {
-                            map.getViewport().addEventListener('mousemove', showLabelOnEvent);
+                            map.getViewport().addEventListener('mousemove', handleInteraction);
                         }
 
-                        if (properties.label && properties.label.show === false &&
-                            properties.label.showOnMouseClick) {
-                            map.getViewport().addEventListener('click', showLabelOnEvent);
+                        if ((properties.label && properties.label.show === false &&
+                            properties.label.showOnMouseClick) ||
+                            properties.onClick) {
+                            map.getViewport().addEventListener('click', handleInteraction);
                             map.getViewport().querySelector('canvas.ol-unselectable').addEventListener(
-                                'touchend', showLabelOnEvent);
+                                'touchend', handleInteraction);
                         }
                     }, true);
                 });

--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -152,7 +152,9 @@ angular.module('openlayers-directive')
                                 }
 
                                 if (properties.onClick && (evt.type === 'click' || evt.type === 'touchend')) {
-                                    properties.onClick.call(marker, evt, properties);
+                                    scope.$apply(function() {
+                                        properties.onClick.call(marker, evt, properties);
+                                    });
                                 }
                                 map.getTarget().style.cursor = 'pointer';
                             }


### PR DESCRIPTION
Fixes https://github.com/tombatossals/angular-openlayers-directive/issues/76

This allows to define marker click (and tap) handlers in this manner:
```
// In the controller
$scope.marker = {
  lat: 48.858093,
  lon: 2.294694,
  onClick: function (event, properties) {
    console.log(this); // ol.Feature instance
    console.log(properties); // === $scope.marker
  }
}
```

```
<!-- In the template -->
<ol-marker ol-marker-properties="marker" ></ol-marker>
```
