### PR TITLE
Enhancement: $log.warn when no ol3 source could be created with the provided source type

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -426,6 +426,11 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 break;
         }
 
+        // log a warning when no source could be created for the given type
+        if(!oSource){
+          $log.warn('[AngularJS - Openlayers] - No source could be found for type "' + source.type + '"');
+        }
+
         return oSource;
     };
 


### PR DESCRIPTION
Currently, if for some reason you don't specify the correct source type (i.e. Stamen, BingMaps etc...) you get this error on the console, which doesn't allow to immediately track down the real cause.
![image](https://cloud.githubusercontent.com/assets/542458/7510660/e3f45de6-f49e-11e4-9701-a15e1acf28d4.png)

This PR adds a `$log.warn` indicating that no ol3 compatible source could be created out of the provided type. Thus you get something like this:
![image](https://cloud.githubusercontent.com/assets/542458/7510680/0e092684-f49f-11e4-8932-51eee5972c08.png)

Personally this would have helped me find my issue much faster :smiley: 

@tombatossals What's your opinion on this?
