### PR TITLE
Add CSS to bower "main prop

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
     "openlayers"
   ],
   "main": [
-    "dist/angular-openlayers-directive.min.js"
+    "dist/angular-openlayers-directive.min.js",
+    "dist/angular-openlayers-directive.css"
   ],
   "dependencies": {
     "angular": "*",


### PR DESCRIPTION
By also adding the distribution CSS to the "main" property on the bower.json file, grunt libs like [wiredep](https://github.com/taptapship/wiredep) can automatically inject it into the HTML.