### PR TITLE
fix(olHelpers): text styles might contain text strings

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -119,7 +119,12 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     return optionalFactory(styleObject, valConstructor);
                 } else {
                     styleObject[val] = recursiveStyle(style, val);
-                    styleObject[val] = optionalFactory(styleObject[val], styleMap[val]);
+
+                    // if the value is 'text' and it contains a String, then it should be interpreted
+                    // as such, 'cause the text style might effectively contain a text to display
+                    if(val !== 'text' && typeof styleObject[val] !== 'string') {
+                       styleObject[val] = optionalFactory(styleObject[val], styleMap[val]);
+                    }
                 }
             });
         } else {


### PR DESCRIPTION
Text styles might contain a property 'text' which should be displayed directly.

```
{
   "text":{
      "text":"text text",
      "offsetX":0,
      "offsetY":0,
      "scale":3,
      "rotation":0,
      "fill":{
         "color":"rgba(255,128,0,1)"
      },
      "stroke":{
         "color":"rgba(128,128,128,1)",
         "width":1
      }
   }
}
```

Problem was that since 'text' is a style keyword, the previous implementation
looped into it, trying to convert the 'text text' string into an ol3 style
object.