### PR TITLE
Allow map view events to be set like map and vector layer events

### DIFF
--- a/src/directives/openlayers.js
+++ b/src/directives/openlayers.js
@@ -29,6 +29,7 @@ angular.module('openlayers-directive', ['ngSanitize']).directive('openlayers', f
                 var isDefined = olHelpers.isDefined;
                 var createLayer = olHelpers.createLayer;
                 var setMapEvents = olHelpers.setMapEvents;
+                var setViewEvents = olHelpers.setViewEvents;
                 var createView = olHelpers.createView;
                 var defaults = olMapDefaults.setDefaults(scope);
 
@@ -99,6 +100,9 @@ angular.module('openlayers-directive', ['ngSanitize']).directive('openlayers', f
 
                 // Set the Default events for the map
                 setMapEvents(defaults.events, map, scope);
+
+                //Set the Default events for the map view
+                setViewEvents(defaults.events, map, scope);
 
                 // Resolve the map object to the promises
                 scope.setMap(map);

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -674,6 +674,17 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
             }
         },
 
+        setViewEvents: function (events, map, scope) {
+            if (isDefined(events) && angular.isArray(events.view)) {
+                var view = map.getView();
+                angular.forEach(events.view, function(eventType){
+                    view.on(eventType, function (event) {
+                        scope.$emit('openlayers.view.' + eventType, view, event);
+                    });
+                });
+            }
+        },
+
         detectLayerType: detectLayerType,
 
         createLayer: function(layer, projection, name) {


### PR DESCRIPTION
I could not find a way to alert on view events (ie; resolution changes).  This solution seemed to work well, and matches the syntax of the other events.