### PR TITLE
Add null check to olLayer before checking its name (setVectorLayerEvents)

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -679,7 +679,11 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                         var pixel = map.getEventPixel(evt);
                         var feature = map.forEachFeatureAtPixel(pixel, function(feature, olLayer) {
                             // only return the feature if it is in this layer (based on the name)
-                            return (olLayer.get('name') === layerName) ? feature : null;
+                            // return undefined if layer is null or name does not match so event is not dispatched
+                            if(angular.isDefined(olLayer) && olLayer != null){
+                                return (olLayer.get('name') === layerName) ? feature : undefined;
+                            }
+                            return undefined;
                         });
                         if (isDefined(feature)) {
                             scope.$emit('openlayers.layers.' + layerName + '.' + eventType, feature, evt);

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -5,7 +5,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
     };
 
     var isDefinedAndNotNull = function(value){
-        return angular.isDefined(value) && value != null;
+        return angular.isDefined(value) && value !== null;
     };
 
     var setEvent = function(map, eventType, scope) {

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -554,9 +554,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
         },
 
         // Determine if a reference is defined and not null
-        isDefinedAndNotNull: function(value) {
-            return angular.isDefined(value) && value !== null;
-        },
+        isDefinedAndNotNull: isDefinedAndNotNull,
 
         // Determine if a reference is a string
         isString: function(value) {

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -4,6 +4,10 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
         return angular.isDefined(value);
     };
 
+    var isDefinedAndNotNull = function(value){
+        return angular.isDefined(value) && value != null;
+    };
+
     var setEvent = function(map, eventType, scope) {
         map.on(eventType, function(event) {
             var coord = event.coordinate;
@@ -679,13 +683,9 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                         var pixel = map.getEventPixel(evt);
                         var feature = map.forEachFeatureAtPixel(pixel, function(feature, olLayer) {
                             // only return the feature if it is in this layer (based on the name)
-                            // return undefined if layer is null or name does not match so event is not dispatched
-                            if(angular.isDefined(olLayer) && olLayer != null){
-                                return (olLayer.get('name') === layerName) ? feature : undefined;
-                            }
-                            return undefined;
+                            return (isDefinedAndNotNull(olLayer) && olLayer.get('name') === layerName) ? feature : null;
                         });
-                        if (isDefined(feature)) {
+                        if (isDefinedAndNotNull(feature)) {
                             scope.$emit('openlayers.layers.' + layerName + '.' + eventType, feature, evt);
                         }
                     });


### PR DESCRIPTION
I came upon a case where I could get a TypeError error while checking against the layer name of the olLayer if the object was null (rapidly updating system).  

The current code could allow an openlayers.layers event to be dispatched when the feature was not part of the layer (since null will pass angular.isDefined() with a true value).  I updated the return value to undefined to prevent the event from being fired (please disregard this pull request if the current behavior is intentional). 