### PR TITLE
fix(olHelpers): change ol.tilegrid.XYZ to ol.tilegrid.createXYZ

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -421,7 +421,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     projection: projection,
                     attributions: createAttribution(source),
                     format: source.format,
-                    tileGrid: new ol.tilegrid.XYZ({
+                    tileGrid: new ol.tilegrid.createXYZ({
                         maxZoom: source.maxZoom || 19
                     })
                 });


### PR DESCRIPTION
fix for error with new versions of openlayers where .XYZ returns "not a function"