### PR TITLE
feat(olHelpers): allow custom attributes to be added to a layer

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -803,6 +803,13 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 oLayer.set('name', layer.name);
             }
 
+            // set custom layer properties if given
+            if (isDefined(layer.customAttributes)) {
+                for (var key in layer.customAttributes) {
+                    oLayer.set(key, layer.customAttributes[key]);
+                }
+            }
+
             return oLayer;
         },
 


### PR DESCRIPTION
This update allows custom attributes to be added to a layer when the layer
is defined.  For instance if a user wants to add a layer property 'selectable'
they can defined it as: customAttributes: { 'selectable': true }