### PR TITLE
Update olHelpers.js

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -903,7 +903,8 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
         insertLayer: function(layers, index, layer) {
             if (layers.getLength() < index) {
                 while (layers.getLength() < index) {
-                    layers.push(null);
+                    var nullLayer = new ol.layer.Image(); 
+                    layers.push(nullLayer);
                 }
                 layer.index = index;
                 layers.push(layer);


### PR DESCRIPTION
OL3 in new version fail when you add a layer null.

If you use index in layers  with space between index. This generate a critical javascript error.

This is my first fix in a github repository and my mother language is spanish.

Sorry for the inconvenience

Tested with openlayer 3.11