### PR TITLE
feat(olHelpers): added builtin overviewmap control

### DIFF
--- a/examples/105-controls-overviewmap-example.html
+++ b/examples/105-controls-overviewmap-example.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html ng-app="demoapp">
+  <head>
+    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/angular/angular.min.js"></script>
+    <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
+    <script src="../dist/angular-openlayers-directive.js"></script>
+    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
+    <style>
+        .ol-overviewmap-box {
+            border: 2px solid red;
+        }
+    </style>
+    <script>
+      var app = angular.module("demoapp", ["openlayers-directive"]);
+      app.controller("ControlOverviewmapController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {
+        angular.extend($scope, {
+            center: {
+                lat: 43.88,
+                lon: 7.57,
+                zoom: 4
+            },
+            layers: {
+                main: {
+                    source: {
+                        type: 'BingMaps',
+                        key: 'Aj6XtE1Q1rIvehmjn2Rh1LR2qvMGZ-8vPS9Hn3jCeUiToM77JFnf-kFRzyMELDol',
+                        imagerySet: 'Aerial'
+                    }
+                }
+            },
+            controls: [
+                { name: 'zoom', active: true },
+                { name: 'overviewmap', active: true, collapsed:false }
+            ]
+        });
+      } ]);
+      </script>
+  </head>
+  <body ng-controller="ControlOverviewmapController">
+     <openlayers ol-center="center" ol-layers="layers">
+         <ol-control name="{{ control.name }}" ng-repeat="control in controls|filter: {active: true}"  ol-control-properties="control"></ol-control>
+     </openlayers>
+     <h1>Overview control example</h1>
+     <p>Example of the overviewmap control. Controls object:</p>
+     <pre ng-bind="controls | json"></pre>
+  </body>
+</html>

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -38,6 +38,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
             attribution: ol.control.Attribution,
             fullscreen: ol.control.FullScreen,
             mouseposition: ol.control.MousePosition,
+            overviewmap: ol.control.OverviewMap,
             rotate: ol.control.Rotate,
             scaleline: ol.control.ScaleLine,
             zoom: ol.control.Zoom,


### PR DESCRIPTION
Added buildin ol3 overviewmap control to be available by name in olControl directive.
Using: `<ol-control name="overviewmap"> </ol-control>`
Also added relevant example.