### PR TITLE
fix(layer): change min/max resolution logic to fix #213

### DIFF
--- a/src/directives/layer.js
+++ b/src/directives/layer.js
@@ -205,15 +205,17 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
                         }
 
                         //set min resolution
-                        if (isDefined(properties.minResolution) &&
-                            !equals(properties.minResolution, oldProperties.minResolution) || isNewLayer(olLayer)) {
-                            olLayer.setMinResolution(properties.minResolution);
+                        if (!equals(properties.minResolution, oldProperties.minResolution) || isNewLayer(olLayer)) {
+                            if (isDefined(properties.minResolution)) {
+                                olLayer.setMinResolution(properties.minResolution);
+                            }
                         }
 
                         //set max resolution
-                        if (isDefined(properties.maxResolution) &&
-                            !equals(properties.maxResolution, oldProperties.maxResolution) || isNewLayer(olLayer)) {
-                            olLayer.setMaxResolution(properties.maxResolution);
+                        if (!equals(properties.maxResolution, oldProperties.maxResolution) || isNewLayer(olLayer)) {
+                            if (isDefined(properties.maxResolution)) {
+                                olLayer.setMaxResolution(properties.maxResolution);
+                            }
                         }
                     }
                 }, true);


### PR DESCRIPTION
There was an error in the logic in version 1.3.0 of the
directive which caused Tile layers with TileWMS sources
to not render when the layer was updated.  Plunker which
demonstrates fix http://plnkr.co/edit/NI7GkRkhJvxXM8OxroMw?p=info

closes #213