### PR TITLE
refactor(olData): move obtainEffectiveMapId function in olData instead using it from olHelpers, reducing dependency injection

### DIFF
--- a/src/services/olData.js
+++ b/src/services/olData.js
@@ -1,6 +1,4 @@
-angular.module('openlayers-directive').service('olData', function($log, $q, olHelpers) {
-
-    var obtainEffectiveMapId = olHelpers.obtainEffectiveMapId;
+angular.module('openlayers-directive').service('olData', function($log, $q) {
 
     var maps = {};
 
@@ -47,5 +45,27 @@ angular.module('openlayers-directive').service('olData', function($log, $q, olHe
         var defer = getDefer(maps, scopeId);
         return defer.promise;
     };
+
+    function obtainEffectiveMapId(d, mapId) {
+        var id;
+        var i;
+        if (!angular.isDefined(mapId)) {
+            if (Object.keys(d).length === 1) {
+                for (i in d) {
+                    if (d.hasOwnProperty(i)) {
+                        id = i;
+                    }
+                }
+            } else if (Object.keys(d).length === 0) {
+                id = 'main';
+            } else {
+                $log.error('[AngularJS - Openlayers] - You have more than 1 map on the DOM, ' +
+                           'you must provide the map ID to the olData.getXXX call');
+            }
+        } else {
+            id = mapId;
+        }
+        return id;
+    }
 
 });

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -718,28 +718,6 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
             return typeof value === 'boolean';
         },
 
-        obtainEffectiveMapId: function(d, mapId) {
-            var id;
-            var i;
-            if (!angular.isDefined(mapId)) {
-                if (Object.keys(d).length === 1) {
-                    for (i in d) {
-                        if (d.hasOwnProperty(i)) {
-                            id = i;
-                        }
-                    }
-                } else if (Object.keys(d).length === 0) {
-                    id = 'main';
-                } else {
-                    $log.error('[AngularJS - Openlayers] - You have more than 1 map on the DOM, ' +
-                               'you must provide the map ID to the olData.getXXX call');
-                }
-            } else {
-                id = mapId;
-            }
-            return id;
-        },
-
         createStyle: createStyle,
 
         setMapEvents: function(events, map, scope) {


### PR DESCRIPTION
The function obtainEffectiveMapId was declared in the helper and only used in OlData. 
Moving it in OlData prevent future cyclic dependency and a better separation of concern.

Thanks