### PR TITLE
feat(olHelpers): add Zoomify support

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -532,6 +532,15 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     tileUrlFunction: source.tileUrlFunction
                 });
                 break;
+            case 'Zoomify':
+                if (!source.url || !angular.isArray(source.imageSize) || source.imageSize.length !== 2) {
+                    $log.error('[AngularJS - Openlayers] - Zoomify Layer needs valid url and imageSize properties');
+                }
+                oSource = new ol.source.Zoomify({
+                    url: source.url,
+                    size: source.imageSize
+                });
+                break;
         }
 
         // log a warning when no source could be created for the given type


### PR DESCRIPTION
This feature allows the directive to use Zoomify as the source of a layer.

[Zoomify Example as shown in OL3](http://openlayers.org/en/v3.13.1/examples/zoomify.html)
[ol.source.Zoomify API](http://openlayers.org/en/v3.13.1/apidoc/ol.source.Zoomify.html)