### PR TITLE
fix(center): In pixel projection, setZoom is skipped

### DIFF
--- a/src/directives/center.js
+++ b/src/directives/center.js
@@ -131,7 +131,8 @@ angular.module('openlayers-directive').directive('olCenter', function($log, $loc
                         if (defaults.view.projection === 'pixel' || center.projection === 'pixel') {
                             view.setCenter(center.coord);
                         } else {
-                            var actualCenter = ol.proj.transform(viewCenter, defaults.view.projection, center.projection);
+                            var actualCenter =
+                                ol.proj.transform(viewCenter, defaults.view.projection, center.projection);
                             if (!(actualCenter[1] === center.lat && actualCenter[0] === center.lon)) {
                                 setCenter(view, defaults.view.projection, center, map);
                             }

--- a/src/directives/center.js
+++ b/src/directives/center.js
@@ -128,13 +128,13 @@ angular.module('openlayers-directive').directive('olCenter', function($log, $loc
 
                     var viewCenter = view.getCenter();
                     if (viewCenter) {
-                        if (defaults.view.projection === 'pixel') {
+                        if (defaults.view.projection === 'pixel' || center.projection === 'pixel') {
                             view.setCenter(center.coord);
-                            return;
-                        }
-                        var actualCenter = ol.proj.transform(viewCenter, defaults.view.projection, center.projection);
-                        if (!(actualCenter[1] === center.lat && actualCenter[0] === center.lon)) {
-                            setCenter(view, defaults.view.projection, center, map);
+                        } else {
+                            var actualCenter = ol.proj.transform(viewCenter, defaults.view.projection, center.projection);
+                            if (!(actualCenter[1] === center.lat && actualCenter[0] === center.lon)) {
+                                setCenter(view, defaults.view.projection, center, map);
+                            }
                         }
                     }
 
@@ -153,7 +153,7 @@ angular.module('openlayers-directive').directive('olCenter', function($log, $loc
                         var center = map.getView().getCenter();
                         scope.center.zoom = view.getZoom();
 
-                        if (defaults.view.projection === 'pixel') {
+                        if (defaults.view.projection === 'pixel' || scope.center.projection === 'pixel') {
                             scope.center.coord = center;
                             return;
                         }


### PR DESCRIPTION
Instead of returning after `setCenter()`, continue to the `setZoom()` method.
Also check if maybe the center has 'pixel' projection in case it is not set in the defaults.