### PR TITLE
Proof of concept of API implementation.

### DIFF
--- a/src/directives/openlayers.js
+++ b/src/directives/openlayers.js
@@ -45,12 +45,15 @@ angular.module('openlayers-directive', ['ngSanitize']).directive('openlayers', f
                         return result;
                     },
                     centerOnExtent: function() {
-                        var markerLayer = this.getMarkersLayer();
-                        
-                        if(markerLayer !== null) {
-                            var extent = markerLayer.getSource().getExtent();
-                            _mapObject.getView().fit(extent, _mapObject.getSize());
-                        }
+                        var extent = ol.extent.createEmpty();
+                        _mapObject.getLayers().forEach(function (layer) {
+                            var source = layer.getSource();
+
+                            if (source.getExtent) {
+                                ol.extent.extend(extent, source.getExtent());
+                            }
+                        });
+                        _mapObject.getView().fit(extent, _mapObject.getSize());
                     }
                 };
             },

--- a/src/directives/openlayers.js
+++ b/src/directives/openlayers.js
@@ -8,21 +8,50 @@ angular.module('openlayers-directive', ['ngSanitize']).directive('openlayers', f
                 center: '=olCenter',
                 defaults: '=olDefaults',
                 view: '=olView',
-                events: '=olEvents'
+                events: '=olEvents',
+                api: '=?api'
             },
             template: '<div class="angular-openlayers-map" ng-transclude></div>',
             controller: function($scope) {
                 var _map = $q.defer();
+                var _mapObject = null;
                 $scope.getMap = function() {
                     return _map.promise;
                 };
 
                 $scope.setMap = function(map) {
                     _map.resolve(map);
+                    _mapObject = map;
                 };
 
                 this.getOpenlayersScope = function() {
                     return $scope;
+                };
+                
+                $scope.api = {
+                    getMap: function() {
+                        return _mapObject;
+                    },
+                    getMarkersLayer: function() {
+                        var result = null;
+                        
+                        _mapObject.getLayers().forEach(function (lyr) {
+                            if(lyr.get('markers') === true) {
+                                result = lyr;
+                                return;   
+                            }
+                        });
+                        
+                        return result;
+                    },
+                    centerOnExtent: function() {
+                        var markerLayer = this.getMarkersLayer();
+                        
+                        if(markerLayer !== null) {
+                            var extent = markerLayer.getSource().getExtent();
+                            _mapObject.getView().fit(extent, _mapObject.getSize());
+                        }
+                    }
                 };
             },
             link: function(scope, element, attrs) {
@@ -111,7 +140,6 @@ angular.module('openlayers-directive', ['ngSanitize']).directive('openlayers', f
                 // Resolve the map object to the promises
                 scope.setMap(map);
                 olData.setMap(map, attrs.id);
-
             }
         };
     });

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -151,6 +151,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 case 'JSONP':
                 case 'TopoJSON':
                 case 'KML':
+                case 'WKT':
                 case 'TileVector':
                     return 'Vector';
                 default:
@@ -341,6 +342,25 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     attributions: createAttribution(source),
                     url: _url
                 });
+
+                break;
+
+            case 'WKT':
+                if (!(source.wkt)) {
+                    $log.error('[AngularJS - Openlayers] - You need a WKT ' +
+                               'property to add a WKT layer.');
+                    return;
+                }
+                
+                var wktFormat = new ol.format.WKT();
+                       
+                oSource = new ol.source.Vector();
+                var wktFeatures = wktFormat.readFeatures(source.wkt, {
+                    dataProjection: projection,
+                    featureProjection: projection
+                });
+                
+                oSource.addFeatures(wktFeatures);
 
                 break;
 


### PR DESCRIPTION
This pull request adds an (optional) API to the `openlayers-directive`. The API provides direct access to the OpenLayers map instance and a convenience method to center the map on the visible markers.

The motivation for these changes is simple: sometimes there is a demand for interactive features that cannot be achieved with the declarative approach of directives and an API to interact with the map is needed.

At this point, the implementation is to be considered a proof-of-concept. I have not added tests or updated the documentation because I would like to get your feedback first. 
