### PR TITLE
feat: add onLayerCreated callback to manipulate original ol3 layer

### DIFF
--- a/src/directives/layer.js
+++ b/src/directives/layer.js
@@ -3,7 +3,8 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
     return {
         restrict: 'E',
         scope: {
-            properties: '=olLayerProperties'
+            properties: '=olLayerProperties',
+            onLayerCreated: '&'
         },
         replace: false,
         require: '^openlayers',
@@ -49,7 +50,7 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
                             }
                         };
 
-                        olLayer = createLayer(l, projection, attrs.layerName);
+                        olLayer = createLayer(l, projection, attrs.layerName, scope.onLayerCreated);
                         if (detectLayerType(l) === 'Vector') {
                             setVectorLayerEvents(defaults.events, map, scope, attrs.name);
                         }
@@ -77,7 +78,7 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
                     var group;
                     var collection;
                     if (!isDefined(olLayer)) {
-                        olLayer = createLayer(properties, projection);
+                        olLayer = createLayer(properties, projection, scope.onLayerCreated);
                         if (isDefined(properties.group)) {
                             addLayerToGroup(layerCollection, olLayer, properties.group);
                         } else if (isDefined(properties.index)) {
@@ -144,7 +145,7 @@ angular.module('openlayers-directive').directive('olLayer', function($log, $q, o
 
                             collection.removeAt(idx);
 
-                            olLayer = createLayer(properties, projection);
+                            olLayer = createLayer(properties, projection, scope.onLayerCreated);
                             olLayer.set('group', group);
 
                             if (isDefined(olLayer)) {

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -801,12 +801,19 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
 
         detectLayerType: detectLayerType,
 
-        createLayer: function(layer, projection, name) {
+        createLayer: function(layer, projection, name, onLayerCreatedFn) {
             var oLayer;
             var type = detectLayerType(layer);
             var oSource = createSource(layer.source, projection);
             if (!oSource) {
                 return;
+            }
+
+            // handle function overloading. 'name' argument may be
+            // our onLayerCreateFn since name is optional
+            if (typeof(name) === 'function' && !onLayerCreatedFn) {
+                onLayerCreatedFn = name;
+                name = undefined; // reset, otherwise it'll be used later on
             }
 
             // Manage clustering
@@ -866,6 +873,13 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 for (var key in layer.customAttributes) {
                     oLayer.set(key, layer.customAttributes[key]);
                 }
+            }
+
+            // invoke the onSourceCreated callback
+            if (onLayerCreatedFn) {
+                onLayerCreatedFn({
+                    oLayer: oLayer
+                });
             }
 
             return oLayer;


### PR DESCRIPTION
Often it might be needed to be able to manipulate the ol3 layer that's
been handed to ol3 by angular-openlayers-directive. This allows for things like

```html
<openlayers>
	<ol-layer ... on-layer-created="ctrl.onLayerCreated(oLayer)"></ol-layer>
</openlayers>
```

And on the controller/component:

```javascript
function MyController() {
	var vm = this;
	vm.onLayerCreated = function(oLayer) {
		// oLayer is the original ol3 layer that's
		// being registered

		var source = olayer.get('source');
		...
	}
}
```

@ageblade @claustres @Pedrazl @nbiton Would you be willing to review this change? What do u think about such addition? Thoughts welcome :smiley: 