### PR TITLE
feat(path): Support passing custom style.

### DIFF
--- a/src/directives/path.js
+++ b/src/directives/path.js
@@ -3,7 +3,8 @@ angular.module('openlayers-directive').directive('olPath', function($log, $q, ol
     return {
         restrict: 'E',
         scope: {
-            properties: '=olGeomProperties'
+            properties: '=olGeomProperties',
+            style: '=olStyle'
         },
         require: '^openlayers',
         replace: true,
@@ -38,7 +39,7 @@ angular.module('openlayers-directive').directive('olPath', function($log, $q, ol
                         type: 'Polygon',
                         coords: coords,
                         projection: proj,
-                        style: mapDefaults.styles.path
+                        style:  scope.style ? scope.style : mapDefaults.styles.path
                     };
                     var feature = createFeature(data, viewProjection);
                     layer.getSource().addFeature(feature);


### PR DESCRIPTION
This allows to pass styling information to ol-path directive via the "ol-style" property. A constrained example:

```
/* js */
$scope.pathStyle = {
    stroke: {
       color: [0, 0, 255, 0.5],
       width: 5,
    }
};

/* html */
<ol-path ng-repeat="path in paths" coords="{{path.coord}}" ol-style="pathStyle"></ol-path>

```