### PR TITLE
Feature/update openlayers 3.16.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,12 +13,13 @@
   "dependencies": {
     "angular": "1.4.9",
     "angular-sanitize": "1.4.9",
-    "openlayers3": "https://github.com/tombatossals/ol3-compiled.git#3.8.2"
+    "openlayers": "https://github.com/openlayers/ol3/releases/download/v3.16.0/v3.16.0-dist.zip"
   },
   "devDependencies": {
     "jquery": "*",
     "angular-route": "1.4.9",
-    "angular-mocks": "1.4.9"
+    "angular-mocks": "1.4.9",
+    "js-polyfills": "^0.1.20"
   },
   "ignore": [
     "**/.*",

--- a/examples/010-simple-example.html
+++ b/examples/010-simple-example.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
     <script>
         var app = angular.module("demoapp", ['openlayers-directive']);
     </script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
   </head>
   <body>
     <openlayers width="100%" height="400px"></openlayers>

--- a/examples/020-center-example.html
+++ b/examples/020-center-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/021-center-url-hash-example.html
+++ b/examples/021-center-url-hash-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
         app.controller('DemoController', [ '$scope', '$location', '$timeout', function($scope, $location, $timeout) {

--- a/examples/022-center-autodiscover-example.html
+++ b/examples/022-center-autodiscover-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/023-center-constrain-zoom-example.html
+++ b/examples/023-center-constrain-zoom-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/024-center-bounds-example.html
+++ b/examples/024-center-bounds-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller("DemoController", [ "$scope", "olHelpers", function($scope, olHelpers) {

--- a/examples/025-center-projections-example.html
+++ b/examples/025-center-projections-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
         app.filter('transform', function() {

--- a/examples/026-center-no-javascript-example.html
+++ b/examples/026-center-no-javascript-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
     </script>

--- a/examples/030-custom-parameters-example.html
+++ b/examples/030-custom-parameters-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller("DemoController", [ '$scope', function($scope) {

--- a/examples/040-layers-change-tiles-example.html
+++ b/examples/040-layers-change-tiles-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol-debug.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoController', [ '$scope', function($scope) {
@@ -53,7 +53,7 @@
                         active: false,
                         source: {
                             type: 'TileJSON',
-                            url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp'
+                            url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json'
                         }
                     }
                 ],

--- a/examples/041-layers-zoom-tiles-changer-example.html
+++ b/examples/041-layers-zoom-tiles-changer-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.min.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoZoomLevelController', [ "$scope", function($scope) {

--- a/examples/042-layers-opacity-example.html
+++ b/examples/042-layers-opacity-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoController', [ '$scope', function($scope) {
@@ -27,7 +27,7 @@
                     opacity: 0.5,
                     source: {
                         type: 'TileJSON',
-                        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp'
+                        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json'
                     }
                 }
             });

--- a/examples/043-layers-bing-maps-example.html
+++ b/examples/043-layers-bing-maps-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/044-layers-mapquest-maps-example.html
+++ b/examples/044-layers-mapquest-maps-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/045-layers-geojson-example.html
+++ b/examples/045-layers-geojson-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/046-layers-geojson-center-example.html
+++ b/examples/046-layers-geojson-center-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/047-layers-topojson-example.html
+++ b/examples/047-layers-topojson-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/048-layers-static-image-example.html
+++ b/examples/048-layers-static-image-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("StaticImageController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/049-layers-stamen-example.html
+++ b/examples/049-layers-stamen-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/050-layer-geojson-change-style-example.html
+++ b/examples/050-layer-geojson-change-style-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/051-layer-geojson-change-style-with-function-example.html
+++ b/examples/051-layer-geojson-change-style-with-function-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
 

--- a/examples/052-heatmap-example.html
+++ b/examples/052-heatmap-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/053-layers-image-wms-example.html
+++ b/examples/053-layers-image-wms-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/054-add-remove-multiple-layers-example.html
+++ b/examples/054-add-remove-multiple-layers-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {
@@ -22,7 +22,7 @@
                     opacity: 0.5,
                     source: {
                         type: 'TileJSON',
-                        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp'
+                        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json'
                     }
                 },
                 {

--- a/examples/055-layers-geojon-dynamic-load-example.html
+++ b/examples/055-layers-geojon-dynamic-load-example.html
@@ -1,11 +1,11 @@
   <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/056-layers-no-javascript-example.html
+++ b/examples/056-layers-no-javascript-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
     </script>

--- a/examples/057-layers-wmts-example.html
+++ b/examples/057-layers-wmts-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var projection = ol.proj.get('EPSG:3857');
         var projectionExtent = projection.getExtent();

--- a/examples/058-layers-geojson-style-function.html
+++ b/examples/058-layers-geojson-style-function.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
 <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>

--- a/examples/059-layer-clustering.html
+++ b/examples/059-layer-clustering.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("ClusteringController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/060-marker-example.html
+++ b/examples/060-marker-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller("DemoController", [ '$scope', function($scope) {

--- a/examples/061-markers-add-remove-example.html
+++ b/examples/061-markers-add-remove-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
 

--- a/examples/062-markers-label-example.html
+++ b/examples/062-markers-label-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);

--- a/examples/063-markers-properties-example.html
+++ b/examples/063-markers-properties-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);

--- a/examples/064-markers-render-html-inside-labels-example.html
+++ b/examples/064-markers-render-html-inside-labels-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <style>
         .popup-label {

--- a/examples/065-markers-static-image-layer-example.html
+++ b/examples/065-markers-static-image-layer-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);

--- a/examples/066-markers-with-layers-no-javascript-example.html
+++ b/examples/066-markers-with-layers-no-javascript-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);

--- a/examples/067-marker-custom-icon-example.html
+++ b/examples/067-marker-custom-icon-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
@@ -22,7 +22,7 @@
                     }
                 }
             };
-            
+
             angular.extend($scope, {
                 center: {
                     lat: 42.9515,

--- a/examples/070-view-rotation-example.html
+++ b/examples/070-view-rotation-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/080-events-propagation-example.html
+++ b/examples/080-events-propagation-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);
         app.controller('DemoController', [ '$scope', function($scope) {

--- a/examples/081-events-vector-example.html
+++ b/examples/081-events-vector-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol-debug.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {
@@ -20,7 +20,7 @@
                     name: 'mapbox',
                     source: {
                         type: 'TileJSON',
-                        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp'
+                        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json'
                     }
                 },
                 {

--- a/examples/082-events-vector-dynamic-styles-example.html
+++ b/examples/082-events-vector-dynamic-styles-example.html
@@ -40,11 +40,11 @@
 
 
     </style>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" type="text/css" href="http://cloud.github.com/downloads/lafeber/world-flags-sprite/flags32.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);

--- a/examples/083-events-static-image-layer-example.html
+++ b/examples/083-events-static-image-layer-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("StaticImageController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/084-events-add-markers-on-click-example.html
+++ b/examples/084-events-add-markers-on-click-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
         var app = angular.module('demoapp', ['openlayers-directive']);

--- a/examples/085-events-kml-example.html
+++ b/examples/085-events-kml-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("KMLEventsController", [ '$scope', '$http', 'olData', 'olHelpers', function($scope, $http, olData, olHelpers) {

--- a/examples/086-events-multi-layer-vector-example.html
+++ b/examples/086-events-multi-layer-vector-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/090-multiple-maps-example.html
+++ b/examples/090-multiple-maps-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <style>
         .half {
             margin: 0 .2em .2em .2em;

--- a/examples/100-controls-example.html
+++ b/examples/100-controls-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <style>
         .ol-full-screen {

--- a/examples/101-controls-fullscreen-example.html
+++ b/examples/101-controls-fullscreen-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);

--- a/examples/102-controls-measure-example.html
+++ b/examples/102-controls-measure-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);

--- a/examples/103-controls-custom-example.html
+++ b/examples/103-controls-custom-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <style>
         .rotate-north {

--- a/examples/104-controls-options-example.html
+++ b/examples/104-controls-options-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <style>
         .ol-full-screen {

--- a/examples/105-controls-overviewmap-example.html
+++ b/examples/105-controls-overviewmap-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <style>
         .ol-overviewmap-box {

--- a/examples/110-path-example.html
+++ b/examples/110-path-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <link rel="stylesheet" href="../dist/angular-openlayers-directive.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);

--- a/examples/111-layer-tile-vector-example.html
+++ b/examples/111-layer-tile-vector-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
   <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
       var app = angular.module("demoapp", ["openlayers-directive"]);
       app.controller("GeoJSONController", [ '$scope', '$http', 'olData', function($scope, $http, olData) {

--- a/examples/112-layers-esri-basemaps-example.html
+++ b/examples/112-layers-esri-basemaps-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
 <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css" />
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css" />
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoController', ['$scope', function ($scope) {

--- a/examples/113-layers-image-wms-with-attribution-example.html
+++ b/examples/113-layers-image-wms-with-attribution-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
 <head>
-    <script src="../bower_components/openlayers3/build/ol.js"></script>
+    <script src="../bower_components/openlayers/ol.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css"/>
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css"/>
     <script>
         var projection = ol.proj.get('EPSG:3857');
         var projectionExtent = projection.getExtent();

--- a/examples/120-custom-layer-and-projection-example.html
+++ b/examples/120-custom-layer-and-projection-example.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
 <head>
-    <script src="../bower_components/openlayers3/build/ol-debug.js"></script>
+    <script src="../bower_components/openlayers/ol-debug.js"></script>
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../dist/angular-openlayers-directive.js"></script>
-    <link rel="stylesheet" href="../bower_components/openlayers3/build/ol.css"/>
+    <link rel="stylesheet" href="../bower_components/openlayers/ol.css"/>
     <script>
         var app = angular.module("demoapp", ["openlayers-directive"]);
         app.controller('DemoController', ['$scope', function ($scope) {

--- a/grunt/karma.js
+++ b/grunt/karma.js
@@ -9,7 +9,8 @@ module.exports = function (grunt, options) {
             singleRun: true,
             options: {
                 files: [
-                    'bower_components/openlayers3/build/ol-debug.js',
+                    'bower_components/openlayers/ol-debug.js',
+                    'bower_components/js-polyfills/polyfill.js',
                     'bower_components/angular/angular.js',
                     'bower_components/angular-sanitize/angular-sanitize.js',
                     'bower_components/angular-mocks/angular-mocks.js',
@@ -25,7 +26,8 @@ module.exports = function (grunt, options) {
             autoWatch: true,
             options: {
                 files: [
-                    'bower_components/openlayers3/build/ol-debug.js',
+                    'bower_components/openlayers/ol-debug.js',
+                    'bower_components/js-polyfills/polyfill.js',
                     'bower_components/angular/angular.js',
                     'bower_components/angular-sanitize/angular-sanitize.js',
                     'bower_components/angular-mocks/angular-mocks.js',

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -151,8 +151,9 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 case 'JSONP':
                 case 'TopoJSON':
                 case 'KML':
-                case 'TileVector':
                     return 'Vector';
+                case 'TileVector':
+                    return 'TileVector';
                 default:
                     return 'Tile';
             }
@@ -449,7 +450,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 if (!source.url || !source.format) {
                     $log.error('[AngularJS - Openlayers] - TileVector Layer needs valid url and format properties');
                 }
-                oSource = new ol.source.TileVector({
+                oSource = new ol.source.VectorTile({
                     url: source.url,
                     projection: projection,
                     attributions: createAttribution(source),
@@ -869,6 +870,9 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     break;
                 case 'Vector':
                     oLayer = new ol.layer.Vector(layerConfig);
+                    break;
+                case 'TileVector':
+                    oLayer = new ol.layer.VectorTile(layerConfig);
                     break;
             }
 

--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -1016,7 +1016,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
             element.css('display', 'block');
             var ov = new ol.Overlay({
                 position: pos,
-                element: element,
+                element: element[0],
                 positioning: 'center-left'
             });
 


### PR DESCRIPTION
Upgrade openlayers to 3.16.0, and fix some bugs.

* fix TileVector for Removal of ol.source.TileVector (since 3.11.0)
* fix popup for https://github.com/openlayers/ol3/pull/4492 (since 3.12.0)
* fix mapbox url for ol.source.TileJSON changes (since 3.13.0)
* add using js-polyfills by unit tests for https://github.com/openlayers/ol3/pull/4639 (since 3.13.0)

