### PR TITLE
chore(build): fix protractor install

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "load-grunt-config": "^0.17.1",
     "matchdep": "~0.3.0",
     "phantomjs": "^1.9.18",
-    "protractor": "^2.0.0",
+    "protractor": "~2.5.0",
     "publish-latest": "^1.1.2",
     "semantic-release": "^4.3.5"
   },

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -15,7 +15,7 @@ exports.config = {
     // chromeDriver)
 
     // The location of the selenium standalone server .jar file.
-    seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.45.0.jar',
+    seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.47.1.jar',
     // The port to start the selenium server on, or null if the server should
     // find its own unused port.
     seleniumPort: null,


### PR DESCRIPTION
End-to-end tests were failing to run after pulling down the latest version:

    Error: No selenium server jar found at the specified location (...\angular-openlayers-directive\node_modules\protractor\selenium\selenium-server-standalone-2.45.0.jar). Check that the version number is up to date.

`protractor.conf.js` was looking for `selenium-server-standalone-2.45.0.jar`, whereas the version that got pulled down after running `npm install` and `grunt test:e2e` was 2.47.1.  They sometimes update the version of selenium-webdriver in minor version updates of protractor (for example, protractor 2.4.0 updated selenium webdriver to 2.47.0 - see the [protractor changelog](https://github.com/angular/protractor/blob/master/CHANGELOG.md)).

Since `protractor.conf.js` requires an exact version of selenium webdriver, I think package.json needs to pin down the version of protractor using a more restrictive scheme, so we're not picking up minor updates which may potentially break the ability to run e2e tests. That's what this pull request does - the version is now specified using the tilde range specifier (~2.5.0, which matches any 2.5.x version) instead
of caret (^2.0.0 which matches any 2.x.x version).