### PR TITLE
feat(defaults): add support for loadTilesWhileAnimating and loadTilesWhenInteracting options

### DIFF
--- a/examples/030-custom-parameters-example.html
+++ b/examples/030-custom-parameters-example.html
@@ -31,7 +31,9 @@
                         zoom: false,
                         rotate: false,
                         attribution: false
-                    }
+                    },
+                    loadTilesWhileAnimating: true,
+                    loadTilesWhileInteracting: true
                 }
             });
         } ]);

--- a/src/directives/openlayers.js
+++ b/src/directives/openlayers.js
@@ -72,7 +72,9 @@ angular.module('openlayers-directive', ['ngSanitize']).directive('openlayers', f
                     controls: controls,
                     interactions: interactions,
                     renderer: defaults.renderer,
-                    view: view
+                    view: view,
+                    loadTilesWhileAnimating: defaults.loadTilesWhileAnimating,
+                    loadTilesWhileInteracting: defaults.loadTilesWhileInteracting
                 });
 
                 scope.$on('$destroy', function() {

--- a/src/services/olMapDefaults.js
+++ b/src/services/olMapDefaults.js
@@ -136,6 +136,13 @@ angular.module('openlayers-directive').factory('olMapDefaults', function($q, olH
                     newDefaults.styles = angular.extend(newDefaults.styles, userDefaults.styles);
                 }
 
+                if (isDefined(userDefaults.loadTilesWhileAnimating)) {
+                    newDefaults.loadTilesWhileAnimating = userDefaults.loadTilesWhileAnimating;
+                }
+
+                if (isDefined(userDefaults.loadTilesWhileInteracting)) {
+                    newDefaults.loadTilesWhileInteracting = userDefaults.loadTilesWhileInteracting;
+                }
             }
 
             defaults[scopeId] = newDefaults;


### PR DESCRIPTION
Fixes #261.

I also modified the custom parameters example (`030-custom-parameters-example.html`) to include these options. To see this change in action, browse to that example, try panning the map, and note that tiles are being fetched even while you're still dragging.