### PR TITLE
feat(olHelpers): custom imageExtent support for ImageStatic layers

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -538,7 +538,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     attributions: createAttribution(source),
                     imageSize: source.imageSize,
                     projection: projection,
-                    imageExtent: projection.getExtent(),
+                    imageExtent: source.imageExtent ? source.imageExtent : projection.getExtent(),
                     imageLoadFunction: source.imageLoadFunction
                 });
                 break;


### PR DESCRIPTION
added a custom set of imageExtent to imageStatic layers.

example:
```
/* js */
app.controller("StaticImageController", [ '$scope', function($scope) {
        angular.extend($scope, {
            center: {
                coord: [ 900, 600 ],
                zoom: 3
            },
            defaults: {
                view: {
                    projection: 'pixel',
                    extent: [ 0, 0, 1800, 1200 ]
                }
            },
            static: {
                source: {
                    type: "ImageStatic",
                    url: "http://blog.wallpops.com/wp-content/upLoads/2013/05/WPE0624.jpg",
                    imageSize: [ 1800, 1200 ]
                },
                zIndex: 1
            },
            eiffel: {
                source: {
                    type: "ImageStatic",
                    url: "images/eiffel.jpg",
                    imageSize: [ 120, 180 ],
                    imageExtent: [830, 650, 880, 730]
                },
                opacity: 0.75,
                zIndex: 2
            }
        });
      } ]);

/* html */
<openlayers ol-center="center" ol-defaults="defaults" custom-layers="true" height="600px">
    <ol-layer ol-layer-properties="static"></ol-layer>
    <ol-layer ol-layer-properties="eiffel"></ol-layer>
</openlayers>
```