### PR TITLE
fix(example): modification in example 55

### DIFF
--- a/examples/055-layers-geojon-dynamic-load-example.html
+++ b/examples/055-layers-geojon-dynamic-load-example.html
@@ -17,7 +17,7 @@
                     type: 'GeoJSON',
                     geojson: {
                         object: italy,
-                        projection: 'EPSG:3857'
+                        projection: 'EPSG:4326'
                     }
                 },
                 style: {
@@ -35,7 +35,7 @@
         var sourceTemplate =  {
             type: 'GeoJSON',
             geojson: {
-                projection: 'EPSG:3857',
+                projection: 'EPSG:4326',
                 object: {}
             }
         };


### PR DESCRIPTION
In latest version, example 55 doesn't work because the projection was incorrectly set. This problem appears after the PR #233. The gh-page version isn't up-to-date with the lib version, so the problematic behavior can be seen only on dev env.

 Linked to #259