### PR TITLE
chore(script): add an npm script to install bower dep after npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "semantic-release": "^4.3.5"
   },
   "scripts": {
+    "postinstall" : "bower install",
     "test": "grunt build && grunt karma:unit",
     "build": "grunt build",
     "prepublish": "npm run build",


### PR DESCRIPTION
In order to not have a global bower installed and allow dev to start working just after an `npm install`, I've added a postinstall script which execute bower install (from local env, not global).