### PR TITLE
fix(package.json): remove the post build install of bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "semantic-release": "^4.3.5"
   },
   "scripts": {
-    "postinstall" : "bower install",
     "test": "grunt build && grunt karma:unit",
     "build": "grunt build",
     "prepublish": "npm run build",


### PR DESCRIPTION
This post-install execution leads environnement depending of the library to have the post-install hook triggered, even if it's only a dependency.

Linked to #282