### PR TITLE
fix(olHelpers): fix url for ESRI basemaps World_Light_Gray_Base and World_Dark_Gray_Base

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -51,7 +51,8 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
 
     var esriBaseLayers = ['World_Imagery', 'World_Street_Map', 'World_Topo_Map',
                           'World_Physical_Map', 'World_Terrain_Base',
-                          'Ocean_Basemap', 'NatGeo_World_Map'];
+                          'Ocean_Basemap', 'NatGeo_World_Map',
+                          'World_Light_Gray_Base', 'World_Dark_Gray_Base'];
 
     var styleMap = {
         'style': ol.style.Style,
@@ -354,6 +355,9 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 }
 
                 var _urlBase = 'http://services.arcgisonline.com/ArcGIS/rest/services/';
+                if (source.layer === 'World_Light_Gray_Base' || source.layer === 'World_Dark_Gray_Base') {
+                    _urlBase = _urlBase + 'Canvas/';
+                }
                 var _url = _urlBase + source.layer + '/MapServer/tile/{z}/{y}/{x}';
 
                 oSource = new ol.source.XYZ({


### PR DESCRIPTION
ESRI layer `World_Light_Gray_Base` mentioned in example `112-layers-esri-basemaps-example.html` requires a different `_urlBase` than the other ESRI layers. The same applies to the layer `World_Dark_Gray_Base`.

Linked to #134 
