### PR TITLE
fix(olHelpers): pass extractStyles to ol.format.KML

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -517,9 +517,10 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 var extractStyles = source.extractStyles || false;
                 oSource = new ol.source.Vector({
                     url: source.url,
-                    format: new ol.format.KML(),
-                    radius: source.radius,
-                    extractStyles: extractStyles
+                    format: new ol.format.KML({
+                        extractStyles: extractStyles
+                    }),
+                    radius: source.radius
                 });
                 break;
             case 'Stamen':


### PR DESCRIPTION
`extractStyles` is a parameter for `ol.format.KML`, and not `ol.source.Vector`. This fixes also the bug described in #268.

Linked to #268