### PR TITLE
fix(olHelpers.js, layersSpec.js): passing projection code instead of …

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -388,8 +388,8 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
 
                     var features = geojsonFormat.readFeatures(
                         source.geojson.object, {
-                            featureProjection: projectionToUse,
-                            dataProjection: dataProjection
+                            featureProjection: projectionToUse.getCode(),
+                            dataProjection: dataProjection.getCode()
                         });
 
                     oSource.addFeatures(features);

--- a/test/unit/layersSpec.js
+++ b/test/unit/layersSpec.js
@@ -97,10 +97,10 @@ describe('Directive: openlayers layers', function() {
                         type: 'Feature',
                         geometry: {
                             type: 'Point',
-                            coordinates: [434179, 122450] // Southampton (UK) in EPSG:27700
+                            coordinates: [50.909698, -1.404351] // Southampton (UK) in EPSG:4326
                         }
                     },
-                    projection: 'EPSG:27700'
+                    projection: 'EPSG:4326'
                 }
             }
         };


### PR DESCRIPTION
…projection object, while converting the geojson data to vector feature for fixing the issue (#295)
