### PR TITLE
fix(package.json): update the openlayers version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-      "angular": "~1.4.8",
-      "angular-sanitize": "~1.4.8",
-      "openlayers": "~3.8"
+    "angular": "~1.4.8",
+    "angular-sanitize": "~1.4.8",
+    "openlayers": "~3.18.1"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Openlayers 3.8.x breaks npm install because of a specific version of a dependency to jsdoc. By updating we avoid this dependency.

This fixed issue #311