### PR TITLE
fix(marker.js): add check to scope teardown

### DIFF
--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -155,6 +155,7 @@ angular.module('openlayers-directive').directive('olMarker', function($log, $q, 
                 };
 
                 function unregisterHandlers() {
+                    if (!scope.properties) { return ; }
                     // Remove previous listeners if any
                     map.getViewport().removeEventListener('mousemove', scope.properties.handleInteraction);
                     map.getViewport().removeEventListener('click', scope.properties.handleTapInteraction);

--- a/test/unit/markerSpec.js
+++ b/test/unit/markerSpec.js
@@ -1,0 +1,23 @@
+'use strict';
+/*jshint -W117 */
+/*jshint globalstrict: true*/
+/* jasmine specs for directives go here */
+
+describe('Directive: openlayers marker', function() {
+    var $compile = null;
+    var scope;
+
+    beforeEach(module('openlayers-directive'));
+    beforeEach(inject(function(_$compile_, $rootScope) {
+        $compile = _$compile_;
+
+        scope = $rootScope.$new();
+    }));
+
+    it('should not error on $scope.$destroy', function() {
+        var element = angular.element('<openlayers><ol-marker lat="0" lon="0"></ol-marker></openlayers>');
+        element = $compile(element)(scope);
+        scope.$digest();
+        expect(function() { scope.$destroy(); }).not.toThrow();
+    });
+});


### PR DESCRIPTION
On a $scope.$destroy the unregisterHandler function is called. This function removes all the eventListeners.
The properties object that these listeners are attached to, might not exist. So during the teardown, an error will be raised.

This fixes issue #314