### PR TITLE
feat (olHelpers.js): add layer support for TileArcGISRest source type

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -364,6 +364,18 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
 
                 break;
 
+            case 'TileArcGISRest':
+                if (!source.url) {
+                    $log.error('[AngularJS - Openlayers] - TileArcGISRest Layer needs valid url');
+                }
+
+                oSource = new ol.source.TileArcGISRest({
+                    attributions: createAttribution(source),
+                    url: source.url
+                });
+
+                break;
+
             case 'GeoJSON':
                 if (!(source.geojson || source.url)) {
                     $log.error('[AngularJS - Openlayers] - You need a geojson ' +


### PR DESCRIPTION
Adding support for TileArcGISRest makes it easy to consume a wide variety of ArcGIS MapServer endpoints provided by Esri (beyond those allowed by the EsriBaseMaps type). This also makes it easy to reference custom MapServer endpoints that may be hosted on private servers.


Killed previous PR#316 so I could put this under a feature branch.