### PR TITLE
fix (olHelpers.js): update wrapX default setting...

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -214,7 +214,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     tileLoadFunction: source.tileLoadFunction,
                     attributions: createAttribution(source),
                     tilePixelRatio: pixelRatio > 1 ? 2 : 1,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
             case 'MapBoxStudio':
@@ -232,7 +232,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     tileLoadFunction: source.tileLoadFunction,
                     attributions: createAttribution(source),
                     tileSize: source.tileSize || [512, 512],
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
             case 'ImageWMS':
@@ -261,7 +261,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     crossOrigin: (typeof source.crossOrigin === 'undefined') ? 'anonymous' : source.crossOrigin,
                     params: deepCopy(source.params),
                     attributions: createAttribution(source),
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 };
 
                 if (source.serverType) {
@@ -300,7 +300,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                         matrixIds: source.tileGrid.matrixIds
                     }),
                     style: (source.style === 'undefined') ? 'normal' : source.style,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 };
 
                 if (isDefined(source.url)) {
@@ -318,7 +318,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 oSource = new ol.source.OSM({
                     tileLoadFunction: source.tileLoadFunction,
                     attributions: createAttribution(source),
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
 
                 if (source.url) {
@@ -338,7 +338,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     attributions: createAttribution(source),
                     imagerySet: source.imagerySet ? source.imagerySet : bingImagerySets[0],
                     culture: source.culture,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 };
 
                 if (source.maxZoom) {
@@ -357,7 +357,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 oSource = new ol.source.MapQuest({
                     attributions: createAttribution(source),
                     layer: source.layer,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
 
                 break;
@@ -375,7 +375,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     attributions: createAttribution(source),
                     tileLoadFunction: source.tileLoadFunction,
                     url: _url,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
 
                 break;
@@ -389,7 +389,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     attributions: createAttribution(source),
                     tileLoadFunction: source.tileLoadFunction,
                     url: source.url,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
 
                 break;
@@ -501,7 +501,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     attributions: createAttribution(source),
                     tileLoadFunction: source.tileLoadFunction,
                     crossOrigin: 'anonymous',
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
 
@@ -518,7 +518,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     tileGrid: new ol.tilegrid.createXYZ({
                         maxZoom: source.maxZoom || 19
                     }),
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
 
@@ -549,7 +549,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
 
                         return url;
                     },
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
             case 'TileImage':
@@ -571,7 +571,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                             .replace('{y}', y.toString());
                         return url;
                     },
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
             case 'KML':
@@ -591,7 +591,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 oSource = new ol.source.Stamen({
                     tileLoadFunction: source.tileLoadFunction,
                     layer: source.layer,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
             case 'ImageStatic':
@@ -621,7 +621,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     projection: source.projection,
                     tileUrlFunction: source.tileUrlFunction,
                     tileLoadFunction: source.tileLoadFunction,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
             case 'Zoomify':
@@ -631,7 +631,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 oSource = new ol.source.Zoomify({
                     url: source.url,
                     size: source.imageSize,
-                    wrapX: source.wrapX || true
+                    wrapX: source.wrapX !== undefined ? source.wrapX : true
                 });
                 break;
         }


### PR DESCRIPTION
Original implementation completely missed the fact that the `||` default treats false the same as all 'falsey' values (meaning a value of false is the same as no value), making it impossible to turn off wrapX by setting it to false.

~ as reported by @thmitchell in a comment on #318 
