### PR TITLE
feat(olHelpers.js): initialize layers with custom properties

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -928,7 +928,14 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                 });
             }
 
-            var layerConfig = { source: oSource };
+            var layerConfig = {};
+            for (var property in layer) {
+                if (layer.hasOwnProperty(property) && property.startsWith('$') === false) {
+                    layerConfig[property] = layer[property];
+                }
+            }
+
+            layerConfig.source = oSource;
 
             // ol.layer.Layer configuration options
             if (isDefinedAndNotNull(layer.opacity)) {


### PR DESCRIPTION
Initialize layers with custom properties to bind custom information on
ol.layer objects.