### PR TITLE
feat(olHelper): auto-detection of attribution

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -680,9 +680,39 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
     var createAttribution = function(source) {
         var attributions = [];
         if (isDefined(source.attribution)) {
-            attributions.unshift(new ol.Attribution({html: source.attribution}));
+            // opt-out -> default tries to show an attribution
+            if (!(source.attribution === false)) { // jshint ignore:line
+                // we got some HTML so display that as the attribution
+                attributions.unshift(new ol.Attribution({html: source.attribution}));
+            }
+        } else {
+            // try to infer automatically
+            var attrib = extractAttributionFromSource(source);
+            if (attrib) {
+                attributions.unshift(attrib);
+            }
         }
+
         return attributions;
+    };
+
+    var extractAttributionFromSource = function(source) {
+        if (source && source.type) {
+            var ol3SourceInstance = ol.source[source.type];
+            if (ol3SourceInstance) {
+                // iterate over the object's props and try
+                // to find the attribution one as it differs
+                for (var prop in ol3SourceInstance) {
+                    if (ol3SourceInstance.hasOwnProperty(prop)) {
+                        if (prop.toLowerCase().indexOf('attribution') > -1) {
+                            return ol.source[source.type][prop];
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     };
 
     var createGroup = function(name) {


### PR DESCRIPTION
This change tries to infer the attribution given the source configuration of the ol3 object. Apparently each OL3 source type might have different properties for storing the attribution. Thus the code needs to iterate over them and "search" for the presence of it.

WARNING: This also slightly changes the default behavior, meaning while currently the attribution had to be enabled explicitly you now have to opt-out by setting the `source.attribution = false`.