### PR TITLE
fix(openlayers.js): Memory leak issue

### DIFF
--- a/src/directives/openlayers.js
+++ b/src/directives/openlayers.js
@@ -79,6 +79,8 @@ angular.module('openlayers-directive', ['ngSanitize']).directive('openlayers', f
 
                 scope.$on('$destroy', function() {
                     olData.resetMap(attrs.id);
+                    map.setTarget(null);
+                    map = null;
                 });
 
                 // If no layer is defined, set the default tileLayer


### PR DESCRIPTION
Set map object to null when controller is destroyed. Was causing memory leaks, Fix for #393